### PR TITLE
Update cmake to use new version of Qt6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ CMakeLists.txt.user*
 
 # Flatpak-builder state directory
 .flatpak-builder
+
+# vscode directory
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # =============== Project initialization ===============
 # ======================================================
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 
 project(tuned-switcher
     VERSION 0.7.2
@@ -77,8 +77,8 @@ set(QT_COMPONENTS
     Widgets
 )
 
-find_package(Qt6 6.2.0
-    COMPONENTS ${QT_COMPONENTS}
+find_package(Qt6 6.8.0
+    REQUIRED COMPONENTS ${QT_COMPONENTS}
     QUIET
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # =============== Project initialization ===============
 # ======================================================
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.12)
 
 project(tuned-switcher
     VERSION 0.7.2


### PR DESCRIPTION
Describe your changes below:

- Added `.vscode` directory to `.gitignore` 
- Changed CMakelists.txt to use Qt 6.8 instead of 6.2. 
- Added `REQUIRED` to `COMPONENTS ${QT_COMPONENTS}` in the `find_package` command

Closes: #65 