### PR TITLE
Explicitly set the correct constants during initialization

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -25,7 +25,11 @@
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
+    QApplication::setApplicationName(AppConstants::ProductNameInternal);
+    QApplication::setApplicationVersion(AppConstants::ProductVersion);
     QApplication::setDesktopFileName(AppConstants::LauncherName);
+    QApplication::setOrganizationName(AppConstants::ProductCompany);
+    QApplication::setOrganizationDomain(AppConstants::DomainSchemeName);
 
     TranslationManager *translator = new TranslationManager();
     a.installTranslator(translator -> GetQtTranslator());

--- a/src/app/mainwindow/mainwindow.cpp
+++ b/src/app/mainwindow/mainwindow.cpp
@@ -82,7 +82,7 @@ void MainWindow::mouseReleaseEvent(QMouseEvent* event)
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-    QSettings settings(AppConstants::ProductCompany, AppConstants::ProductNameInternal);
+    QSettings settings;
     settings.setValue(QStringLiteral("geometry"), saveGeometry());
     settings.setValue(QStringLiteral("windowState"), saveState());
     settings.sync();
@@ -155,7 +155,7 @@ void MainWindow::subscribeToEvents()
 
 void MainWindow::loadSettings()
 {
-    QSettings settings(AppConstants::ProductCompany, AppConstants::ProductNameInternal);
+    QSettings settings;
     restoreGeometry(settings.value(QStringLiteral("geometry")).toByteArray());
     restoreState(settings.value(QStringLiteral("windowState")).toByteArray());
 }

--- a/src/lib/appconstants/appconstants.h.in
+++ b/src/lib/appconstants/appconstants.h.in
@@ -13,7 +13,6 @@
 */
 
 #include <QString>
-#include <QVersionNumber>
 
 /**
  * Namespace for working with various constants used in project.
@@ -38,9 +37,9 @@ namespace AppConstants {
     const QString ProductNameInternal = QStringLiteral("@CMAKE_PROJECT_NAME@");
 
     /**
-     * Stores the application version number as a QVersionNumber.
+     * Stores the application version number as a string.
     */
-    const QVersionNumber ProductVersion = QVersionNumber::fromString(QStringLiteral("@CMAKE_PROJECT_VERSION@"));
+    const QString ProductVersion = QStringLiteral("@CMAKE_PROJECT_VERSION@");
 
     /**
      * Stores the application launcher (.desktop) file name.


### PR DESCRIPTION
Describe your changes below:

Explicitly set the correct constants during the app initialization for better integration and easier saving/restoring of settings.